### PR TITLE
Ability to replace values in the template before echoing

### DIFF
--- a/blacklist.go
+++ b/blacklist.go
@@ -104,7 +104,6 @@ func (b *Blacklist) Serve(ctx iris.Context) {
 	b.log.Print(fmt.Sprintf("checking whether the user agent %s is blocked or not", userAgent))
 
 	b.replaceStrings["ip"] = ctx.Request().RemoteAddr
-	b.replaceStrings["service"] = "Joe Nuts"
 
 	for _, v := range b.blockedUserAgents {
 		if v == userAgent {

--- a/blacklist.go
+++ b/blacklist.go
@@ -14,7 +14,6 @@ import (
 // If ReplaceStrings is not null, then {{key}} will be replaced by the corresponding value
 // By default, there are a few replace strings which automatically get populated, such as the user's IP address
 type Options struct {
-	Debug             bool
 	BlockedResponse   []byte
 	BlockedIPs        []string
 	BlockedUserAgents []string

--- a/example/main.go
+++ b/example/main.go
@@ -17,7 +17,6 @@ func main() {
 	// by default, ReplaceStrings will have {{ip}} replaced with the user's IP address (if it exists in the specified template)
 	// so you don't need to add that
 	blacklistMiddleware := blacklist.New(blacklist.Options{
-		Debug:             true,
 		BlockedIPs:        []string{"127.0.0.1", "::1"},
 		BlockedUserAgents: []string{},
 		ReplaceStrings:    replaceValues,

--- a/example/main.go
+++ b/example/main.go
@@ -8,13 +8,19 @@ import (
 func main() {
 	app := iris.New()
 
+	replaceValues := make(map[string]string, 1)
+	replaceValues["message"] = "This is a test"
+
 	// we dont specify BlockedResponse since blacklist.New will automatically download the template file
 	// and use that if we dont specify one
 	// you can always specify one yourself, it's just a byte array
+	// by default, ReplaceStrings will have {{ip}} replaced with the user's IP address (if it exists in the specified template)
+	// so you don't need to add that
 	blacklistMiddleware := blacklist.New(blacklist.Options{
 		Debug:             true,
 		BlockedIPs:        []string{"127.0.0.1", "::1"},
 		BlockedUserAgents: []string{},
+		ReplaceStrings:    replaceValues,
 	})
 
 	app.Use(blacklistMiddleware)


### PR DESCRIPTION
So if you have {{service}} in your template, you'd simply pass it "service" as the key, and "something" as the value - then it'll replace when it comes to sending the response to the user